### PR TITLE
Spring ch04: fixed some typo's and used non-deprecated version of queryForObject

### DIFF
--- a/spring-framework/assets/docs/04_PersistenceWithJDBC.adoc
+++ b/spring-framework/assets/docs/04_PersistenceWithJDBC.adoc
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 ////
-= Persistence with Spring
+= Persistence with JDBC
 :toc:
 :toclevels: 4
 
@@ -30,14 +30,14 @@ Some commonly used persistence mechanisms are explained in the next few chapters
 This chapter delves into the most basic persistence, to explain the fundamentals.
 
 Note that the examples use an embedded database, which does not replace the need for an actual
-external database in production applications. The logic, hoever, remain the same.
+external database in production applications. The logic, however, remains the same.
 
 Similar to previous chapters two examples of a spring-configuration: XML and Java based are used.
 
 == Spring Persistence - Examples
 Both examples share some common features.
 
-- Relies on an embedded database. An embedded database H2 is used an in-memory database.
+- Relies on an embedded database. An embedded database H2 is used as in-memory database.
 
 - Any changes made during a run will be wiped out when the application terminates, since this is
 an embedded database, scoped to the execution of the application.
@@ -74,7 +74,7 @@ This class loads the `spring-config.xml` using a `ClassPathXmlApplicationContext
 
 . The XML-based configuration *spring-config.xml* loads a few beans into the Spring context. +
 ⇒ link:../../ch04_spring-persistence/src/main/resources/spring-config.xml[spring-config.xml] +
-The XML creates a datasource bean, which then invokes the creates database tables and seeds values
+The XML creates a datasource bean, which then creates the database tables and seeds values
 from the two SQL files. This is done via `jdbc:scripts`.
 
 . The _Data Access Object_ performs the tasks of operating with the database. The class used for
@@ -125,10 +125,10 @@ the DAO to invoke data operations on the dataSource.
 . The _Data Access Object_ performs the tasks of operating with the database. The class used for
 this example implements the `ColoredShapeDao` interface. +
 ⇒ link:../../ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDaoImplEx02.java[ColoredShapeDaoImplEx02.java] +
-This class is an implementation of the `ColoredShapeDao` interface. All CRUD methods are
-implemented. The DAO implementation also defines a `RowMapper`, as a `ColoredShapeMapper`, that
-maps a `ResultSet` to a `ColoredShape` Java object. An `@Autowired` annotation on the constructor
-_injects_ the `dataSource` into the DAO.
+This class is an implementation of the `ColoredShapeDao` interface and is loaded into the Spring context via the
+`@Repository`. All CRUD methods are implemented. The DAO implementation also defines a `RowMapper`, as a
+`ColoredShapeMapper`, that maps a `ResultSet` to a `ColoredShape` Java object. An `@Autowired` annotation on the
+constructor _injects_ the `dataSource` into the DAO.
 
 The DBConfiguration declares an embedded database as a dataSource. The dataSource is the most
 important bean in persistence. An autowiring of this dataSource to the Data Access Object (DAO),

--- a/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDao.java
+++ b/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDao.java
@@ -33,7 +33,7 @@ public interface ColoredShapeDao {
     ColoredShape getColoredShape(int id);
 
     /**
-     * R of the CRUD Read all ColoredShape instnces in the table
+     * R of the CRUD Read all ColoredShape instances in the table
      */
     List<ColoredShape> listColoredShapes();
 
@@ -43,7 +43,7 @@ public interface ColoredShapeDao {
     void update(int id, String color, String shape);
 
     /**
-     * D of the CRUD Delete a ColoredShape from the table corresponding to a an id.
+     * D of the CRUD Delete a ColoredShape from the table corresponding to an id.
      */
     void delete(int id);
 

--- a/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDaoImplEx01.java
+++ b/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDaoImplEx01.java
@@ -53,7 +53,7 @@ public class ColoredShapeDaoImplEx01 implements ColoredShapeDao {
 
         String sql = "select * from coloredshape where id = ?";
 
-        ColoredShape coloredShape = jdbcTemplate.queryForObject(sql, new Object[]{id}, new ColoredShapeMapper());
+        ColoredShape coloredShape = jdbcTemplate.queryForObject(sql, new ColoredShapeMapper(), id);
 
         return coloredShape;
     }

--- a/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDaoImplEx02.java
+++ b/spring-framework/ch04_spring-persistence/src/main/java/bnymellon/training/spring/framework/dao/ColoredShapeDaoImplEx02.java
@@ -57,7 +57,7 @@ public class ColoredShapeDaoImplEx02 implements ColoredShapeDao {
 
         String sql = "select * from coloredshape where id = ?";
 
-        ColoredShape coloredShape = jdbcTemplate.queryForObject(sql, new Object[]{id}, new ColoredShapeMapper());
+        ColoredShape coloredShape = jdbcTemplate.queryForObject(sql, new ColoredShapeMapper(), id);
 
         return coloredShape;
     }


### PR DESCRIPTION
Fixed some typo's in documentation, added some explanation about @Repository annotation.
Fixed some typo's in classes.
Used the non-deprecated version of queryForObject.